### PR TITLE
Fix jasmine eslint

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,15 +1,16 @@
 module.exports = {
-    "env": {
-        "commonjs": true,
-        "es2021": true,
-        "node": true
-    },
-    "extends": [
-        "standard"
-    ],
-    "parserOptions": {
-        "ecmaVersion": 'latest'
-    },
-    "rules": {
-    }
-};
+  env: {
+    commonjs: true,
+    es2021: true,
+    node: true,
+    jasmine: true
+  },
+  extends: [
+    'standard'
+  ],
+  parserOptions: {
+    ecmaVersion: 'latest'
+  },
+  rules: {
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 node_modules
+.idea/
+.vscode/

--- a/spec/cohortSearch.spec.js
+++ b/spec/cohortSearch.spec.js
@@ -1,6 +1,6 @@
 // TEST CODE
 const { cohortSearch } = require('../src/cohortSearch.js')
 
-describe("Cohort Search", () => {
+describe('Cohort Search', () => {
   // to be implemented
 })


### PR DESCRIPTION
Currently, ESLint is unable to recognise the Jasmine library, meaning it highlights `describe`, `it`, etc as undefined. 

This PR fixes that.